### PR TITLE
Added python decoder

### DIFF
--- a/src/blurhash/__init__.py
+++ b/src/blurhash/__init__.py
@@ -48,7 +48,6 @@ def decode(blurhash, width, height, punch = 1, mode = 'RGBA'):
         raise ValueError("Invalid value for argument mode, must be either 'RGB' or 'RGBA'")
 
     channels = _pixel_modes[mode]
-
     blurhash_str = _ffi.new('char[]', bytes(blurhash, "utf-8"))
 
     if not _lib.is_valid_blurhash(blurhash_str) :
@@ -67,9 +66,7 @@ def decode(blurhash, width, height, punch = 1, mode = 'RGBA'):
 
     #garbage collection of pixel buffer
     pixels = _ffi.gc(pixels, _lib.free_pixel_array)
-
     pixels_buffer = _ffi.buffer(pixels, width * height * channels)
-
     image = Image.frombuffer(mode, (width, height), pixels_buffer)
 
     return image

--- a/src/blurhash/__init__.py
+++ b/src/blurhash/__init__.py
@@ -11,7 +11,7 @@ from ._functions import ffi as _ffi, lib as _lib
 from ._version import version as __version__
 
 
-__all__ = 'encode', 'decode', 'is_valid_blurhash', 'DecodeModes', 'BlurhashDecodeError', '__version__'
+__all__ = 'encode', 'decode', 'is_valid_blurhash', 'PixelMode', 'BlurhashDecodeError', '__version__'
 
 class PixelMode(Enum):
     RGB = 3

--- a/src/blurhash/__init__.py
+++ b/src/blurhash/__init__.py
@@ -58,26 +58,26 @@ def decode(blurhash, width, height, punch=1, mode=PixelMode.RGB):
 
     if width <= 0 or type(width) != int:
         raise ValueError(
-          """Argument width={} is not a valid positive integer
-          (must be > 0).""".format(width)
+          "Argument width={} is not a valid positive integer"
+          " (must be > 0).".format(width)
         )
 
     if height <= 0 or type(height) != int:
         raise ValueError(
-          """Argument height={} is not a valid positive integer
-           (must be > 0).""".format(height)
+          "Argument height={} is not a valid positive integer"
+          " (must be > 0).".format(height)
         )
 
     if punch < 1 or type(punch) != int:
         raise ValueError(
-          """Argument punch={} is not a valid positive integer
-          (must be >= 1).""".format(punch)
+          "Argument punch={} is not a valid positive integer"
+          " (must be >= 1).".format(punch)
         )
 
     if not isinstance(mode, PixelMode):
         raise ValueError(
-          """Argument 'mode' must be of type {}
-          but got {}""".format(PixelMode, type(mode))
+          "Argument 'mode' must be of type {}"
+          " but got {}".format(PixelMode, type(mode))
         )
 
     channels = mode.value

--- a/src/blurhash/__init__.py
+++ b/src/blurhash/__init__.py
@@ -58,15 +58,16 @@ def decode(blurhash, width, height, punch = 1, mode = 'RGBA'):
     punch_int = _ffi.cast('int', punch)
     channels_int = _ffi.cast('int', channels)
 
-    pixels = _lib.create_pixels_from_blurhash(blurhash_str, width_int, height_int,
-                                    punch_int, channels)
-    
-    if pixels == _ffi.NULL :
+    pixel_array = _ffi.new('uint8_t[]', width * height * channels)
+
+    result = _lib.create_pixels_from_blurhash(blurhash_str, width_int, height_int,
+                                    punch_int, channels, pixel_array)
+
+    if result == -1 :
         raise Exception("Failed to decode blurhash {}".format(blurhash))
 
     #garbage collection of pixel buffer
-    pixels = _ffi.gc(pixels, _lib.free_pixel_array)
-    pixels_buffer = _ffi.buffer(pixels, width * height * channels)
+    pixels_buffer = _ffi.buffer(pixel_array, width * height * channels)
     image = Image.frombuffer(mode, (width, height), pixels_buffer)
 
     return image

--- a/src/blurhash/__init__.py
+++ b/src/blurhash/__init__.py
@@ -66,7 +66,6 @@ def decode(blurhash, width, height, punch = 1, mode = 'RGBA'):
     if result == -1 :
         raise Exception("Failed to decode blurhash {}".format(blurhash))
 
-    #garbage collection of pixel buffer
     pixels_buffer = _ffi.buffer(pixel_array, width * height * channels)
     image = Image.frombuffer(mode, (width, height), pixels_buffer)
 

--- a/src/blurhash/__init__.py
+++ b/src/blurhash/__init__.py
@@ -11,13 +11,16 @@ from ._functions import ffi as _ffi, lib as _lib
 from ._version import version as __version__
 
 
-__all__ = 'encode', 'decode', 'is_valid_blurhash', 'PixelMode', 'BlurhashDecodeError', '__version__'
+__all__ = 'encode', 'decode', 'is_valid_blurhash', 'PixelMode', \
+          'BlurhashDecodeError', '__version__'
+
 
 class PixelMode(Enum):
     RGB = 3
     RGBA = 4
 
-class BlurhashDecodeError(Exception) :
+
+class BlurhashDecodeError(Exception):
 
     def __init__(self, blurhash):
         self.blurhash = blurhash
@@ -50,24 +53,37 @@ def encode(image_file, x_components, y_components):
 
     return _ffi.string(result).decode()
 
-def decode(blurhash, width, height, punch = 1, mode = PixelMode.RGB):
+
+def decode(blurhash, width, height, punch=1, mode=PixelMode.RGB):
 
     if width <= 0 or type(width) != int:
-        raise ValueError("Argument width={} is not a valid positive integer (must be > 0).".format(width))
+        raise ValueError(
+          """Argument width={} is not a valid positive integer
+          (must be > 0).""".format(width)
+        )
 
     if height <= 0 or type(height) != int:
-        raise ValueError("Argument height={} is not a valid positive integer (must be > 0).".format(height))
+        raise ValueError(
+          """Argument height={} is not a valid positive integer
+           (must be > 0).""".format(height)
+        )
 
     if punch < 1 or type(punch) != int:
-        raise ValueError("Argument punch={} is not a valid positive integer (must be >= 1).".format(punch))
+        raise ValueError(
+          """Argument punch={} is not a valid positive integer
+          (must be >= 1).""".format(punch)
+        )
 
     if not isinstance(mode, PixelMode):
-        raise ValueError("Argument 'mode' must be of type {} but got {}".format(PixelMode, type(mode)))
+        raise ValueError(
+          """Argument 'mode' must be of type {}
+          but got {}""".format(PixelMode, type(mode))
+        )
 
     channels = mode.value
     blurhash_str = _ffi.new('char[]', bytes(blurhash, "utf-8"))
 
-    if not _lib.is_valid_blurhash(blurhash_str) :
+    if not _lib.is_valid_blurhash(blurhash_str):
         raise ValueError("{} is not a valid blurhash".format(blurhash))
 
     width_int = _ffi.cast('int', width)
@@ -77,10 +93,12 @@ def decode(blurhash, width, height, punch = 1, mode = PixelMode.RGB):
 
     pixel_array = _ffi.new('uint8_t[]', width * height * channels)
 
-    result = _lib.create_pixels_from_blurhash(blurhash_str, width_int, height_int,
-                                    punch_int, channels, pixel_array)
+    result = _lib.create_pixels_from_blurhash(blurhash_str,
+                                              width_int, height_int,
+                                              punch_int, channels_int,
+                                              pixel_array)
 
-    if result == -1 :
+    if result == -1:
         raise BlurhashDecodeError(blurhash)
 
     pixels_buffer = _ffi.buffer(pixel_array, width * height * channels)
@@ -88,7 +106,8 @@ def decode(blurhash, width, height, punch = 1, mode = PixelMode.RGB):
 
     return image
 
-def is_valid_blurhash(blurhash) :
+
+def is_valid_blurhash(blurhash):
 
     blurhash_str = _ffi.new('char[]', bytes(blurhash, 'utf-8'))
     return bool(_lib.is_valid_blurhash(blurhash_str))

--- a/src/blurhash/__init__.py
+++ b/src/blurhash/__init__.py
@@ -42,7 +42,7 @@ def encode(image_file, x_components, y_components):
 
     return _ffi.string(result).decode()
 
-def decode(blurhash, width, height, punch, mode = 'RGB'):
+def decode(blurhash, width, height, punch = 1, mode = 'RGBA'):
 
     if not mode in _pixel_modes:
         raise ValueError("Invalid value for argument mode, must be either 'RGB' or 'RGBA'")

--- a/src/blurhash/__init__.py
+++ b/src/blurhash/__init__.py
@@ -13,11 +13,6 @@ from ._version import version as __version__
 
 __all__ = 'encode', 'decode', 'is_valid_blurhash', 'DecodeModes', 'BlurhashDecodeError', '__version__'
 
-_pixel_modes = {
-    "RGB" : 3,
-    "RGBA" : 4
-}
-
 class PixelMode(Enum):
     RGB = 3
     RGBA = 4

--- a/src/blurhash/__init__.py
+++ b/src/blurhash/__init__.py
@@ -1,14 +1,21 @@
 from __future__ import absolute_import
 from itertools import chain
 
+
 from PIL import Image
+
 from six.moves import zip
 
-from ._encode import ffi as _ffi, lib as _lib
+from ._functions import ffi as _ffi, lib as _lib
 from ._version import version as __version__
 
 
-__all__ = 'encode', '__version__',
+__all__ = 'encode', 'decode', '__version__',
+
+_pixel_modes = {
+    "RGB" : 3,
+    "RGBA" : 4
+}
 
 
 def encode(image_file, x_components, y_components):
@@ -34,3 +41,40 @@ def encode(image_file, x_components, y_components):
         raise ValueError('Invalid x_components or y_components')
 
     return _ffi.string(result).decode()
+
+def decode(blurhash, width, height, punch, mode = 'RGB'):
+
+    if not mode in _pixel_modes:
+        raise ValueError("Invalid value for argument mode, must be either 'RGB' or 'RGBA'")
+
+    channels = _pixel_modes[mode]
+
+    blurhash_str = _ffi.new('char[]', bytes(blurhash, "utf-8"))
+
+    if not _lib.is_valid_blurhash(blurhash_str) :
+        raise ValueError("{} is not a valid blurhash".format(blurhash))
+
+    width_int = _ffi.cast('int', width)
+    height_int = _ffi.cast('int', height)
+    punch_int = _ffi.cast('int', punch)
+    channels_int = _ffi.cast('int', channels)
+
+    pixels = _lib.create_pixels_from_blurhash(blurhash_str, width_int, height_int,
+                                    punch_int, channels)
+    
+    if pixels == _ffi.NULL :
+        raise Exception("Failed to decode blurhash {}".format(blurhash))
+
+    #garbage collection of pixel buffer
+    pixels = _ffi.gc(pixels, _lib.free_pixel_array)
+
+    pixels_buffer = _ffi.buffer(pixels, width * height * channels)
+
+    image = Image.frombuffer(mode, (width, height), pixels_buffer)
+
+    return image
+
+def is_valid_blurhash(blurhash) :
+
+    blurhash_str = _ffi.new('char[]', bytes(blurhash, 'utf-8'))
+    return bool(_lib.is_valid_blurhash(blurhash_str))

--- a/src/build_blurhash.py
+++ b/src/build_blurhash.py
@@ -5,10 +5,13 @@ import sys
 
 
 ffibuilder = cffi.FFI()
-ffibuilder.set_source('blurhash._encode', '''
-    const char* blurHashForPixels(int xComponents, int yComponents, int width,
-                                  int height, uint8_t *rgb,
-                                  size_t bytesPerRow);
+ffibuilder.set_source('blurhash._functions', '''
+
+    const char* blurHashForPixels(int x_components, int y_components, int width, int height,
+                                uint8_t * rgb, size_t bytesPerRow);
+    uint8_t * decode(const char* blurhash, int width, int height, int punch, int n_channels);
+    void freePixelArray(uint8_t * pixelsPtr);
+    
 
     const char* create_hash_from_pixels(int x_components, int y_components,
                                        int width, int height, uint8_t* rgb,
@@ -16,12 +19,33 @@ ffibuilder.set_source('blurhash._encode', '''
         return blurHashForPixels(x_components, y_components, width, height,
                                  rgb, bytes_per_row);
     }
-''', sources=['src/encode.c'], extra_compile_args=['-std=gnu99'] if sys.platform != 'win32' else [])
+
+    uint8_t * create_pixels_from_blurhash(const char * blurhash, int width, int height, 
+                                     int punch, int n_channels){
+            return decode(blurhash, width, height, punch, n_channels);
+    }
+
+    int is_valid_blurhash(const char * blurhash) {
+        return isValidBlurhash(blurhash);
+    }
+
+    void free_pixel_array(uint8_t * pixel_ptr) {
+        freePixelArray(pixel_ptr);
+    }
+''', sources=['src/encode.c', 'src/decode.c'], extra_compile_args=['-std=gnu99'] if sys.platform != 'win32' else [])
+
 ffibuilder.cdef('''
     const char* create_hash_from_pixels(int x_components, int y_components,
                                        int width, int height, uint8_t* rgb,
                                        size_t bytes_per_row);
+    uint8_t * create_pixels_from_blurhash(const char * blurhash, int width, int height,
+                                    int punch, int nChannels);
+
+    int is_valid_blurhash(const char * blurhash);
+    
+    void free_pixel_array(uint8_t * pixel_ptr);
 ''')
+
 
 if __name__ == '__main__':
     ffibuilder.compile()

--- a/src/build_blurhash.py
+++ b/src/build_blurhash.py
@@ -6,6 +6,7 @@ import sys
 
 ffibuilder = cffi.FFI()
 ffibuilder.set_source('blurhash._functions', '''
+    #include "common.h"
 
     const char* blurHashForPixels(int x_components, int y_components,
                                   int width, int height,
@@ -34,6 +35,7 @@ ffibuilder.set_source('blurhash._functions', '''
         return isValidBlurhash(blurhash);
     }
 ''', sources=['src/encode.c', 'src/decode.c'],
+        include_dirs=['src/'],
         extra_compile_args=['-std=gnu99'] if sys.platform != 'win32' else []
     )
 

--- a/src/build_blurhash.py
+++ b/src/build_blurhash.py
@@ -7,36 +7,43 @@ import sys
 ffibuilder = cffi.FFI()
 ffibuilder.set_source('blurhash._functions', '''
 
-    const char* blurHashForPixels(int x_components, int y_components, int width, int height,
-                                uint8_t * rgb, size_t bytesPerRow);
+    const char* blurHashForPixels(int x_components, int y_components,
+                                  int width, int height,
+                                  uint8_t * rgb, size_t bytesPerRow);
 
-    int decodeToArray(const char* blurhash, int width, int height, int punch, int n_channels,
+    int decodeToArray(const char* blurhash, int width, int height,
+                      int punch, int n_channels,
                       uint8_t * pixel_array);
 
 
     const char* create_hash_from_pixels(int x_components, int y_components,
-                                       int width, int height, uint8_t* rgb,
-                                       size_t bytes_per_row) {
+                                        int width, int height, uint8_t* rgb,
+                                        size_t bytes_per_row) {
         return blurHashForPixels(x_components, y_components, width, height,
                                  rgb, bytes_per_row);
     }
 
-    int create_pixels_from_blurhash(const char * blurhash, int width, int height,
-                                     int punch, int n_channels, uint8_t * pixel_array){
-            return decodeToArray(blurhash, width, height, punch, n_channels, pixel_array);
+    int create_pixels_from_blurhash(const char * blurhash, int width,
+                                    int height, int punch, int n_channels,
+                                    uint8_t * pixel_array){
+        return decodeToArray(blurhash, width, height,
+                             punch, n_channels, pixel_array);
     }
 
     int is_valid_blurhash(const char * blurhash) {
         return isValidBlurhash(blurhash);
     }
-''', sources=['src/encode.c', 'src/decode.c'], extra_compile_args=['-std=gnu99'] if sys.platform != 'win32' else [])
+''', sources=['src/encode.c', 'src/decode.c'],
+        extra_compile_args=['-std=gnu99'] if sys.platform != 'win32' else []
+    )
 
 ffibuilder.cdef('''
     const char* create_hash_from_pixels(int x_components, int y_components,
-                                       int width, int height, uint8_t* rgb,
-                                       size_t bytes_per_row);
-    int create_pixels_from_blurhash(const char * blurhash, int width, int height,
-                                    int punch, int nChannels, uint8_t * pixel_array);
+                                        int width, int height, uint8_t* rgb,
+                                        size_t bytes_per_row);
+    int create_pixels_from_blurhash(const char * blurhash, int width,
+                                    int height, int punch, int nChannels,
+                                    uint8_t * pixel_array);
 
     int is_valid_blurhash(const char * blurhash);
 

--- a/src/build_blurhash.py
+++ b/src/build_blurhash.py
@@ -9,9 +9,10 @@ ffibuilder.set_source('blurhash._functions', '''
 
     const char* blurHashForPixels(int x_components, int y_components, int width, int height,
                                 uint8_t * rgb, size_t bytesPerRow);
-    uint8_t * decode(const char* blurhash, int width, int height, int punch, int n_channels);
-    void freePixelArray(uint8_t * pixelsPtr);
-    
+
+    int decodeToArray(const char* blurhash, int width, int height, int punch, int n_channels,
+                      uint8_t * pixel_array);
+
 
     const char* create_hash_from_pixels(int x_components, int y_components,
                                        int width, int height, uint8_t* rgb,
@@ -20,17 +21,13 @@ ffibuilder.set_source('blurhash._functions', '''
                                  rgb, bytes_per_row);
     }
 
-    uint8_t * create_pixels_from_blurhash(const char * blurhash, int width, int height, 
-                                     int punch, int n_channels){
-            return decode(blurhash, width, height, punch, n_channels);
+    int create_pixels_from_blurhash(const char * blurhash, int width, int height,
+                                     int punch, int n_channels, uint8_t * pixel_array){
+            return decodeToArray(blurhash, width, height, punch, n_channels, pixel_array);
     }
 
     int is_valid_blurhash(const char * blurhash) {
         return isValidBlurhash(blurhash);
-    }
-
-    void free_pixel_array(uint8_t * pixel_ptr) {
-        freePixelArray(pixel_ptr);
     }
 ''', sources=['src/encode.c', 'src/decode.c'], extra_compile_args=['-std=gnu99'] if sys.platform != 'win32' else [])
 
@@ -38,12 +35,11 @@ ffibuilder.cdef('''
     const char* create_hash_from_pixels(int x_components, int y_components,
                                        int width, int height, uint8_t* rgb,
                                        size_t bytes_per_row);
-    uint8_t * create_pixels_from_blurhash(const char * blurhash, int width, int height,
-                                    int punch, int nChannels);
+    int create_pixels_from_blurhash(const char * blurhash, int width, int height,
+                                    int punch, int nChannels, uint8_t * pixel_array);
 
     int is_valid_blurhash(const char * blurhash);
-    
-    void free_pixel_array(uint8_t * pixel_ptr);
+
 ''')
 
 

--- a/src/common.h
+++ b/src/common.h
@@ -1,0 +1,26 @@
+#ifndef __BLURHASH_COMMON_H__
+#define __BLURHASH_COMMON_H__
+
+#include<math.h>
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+static inline int linearTosRGB(float value) {
+	float v = fmaxf(0, fminf(1, value));
+	if(v <= 0.0031308) return v * 12.92 * 255 + 0.5;
+	else return (1.055 * powf(v, 1 / 2.4) - 0.055) * 255 + 0.5;
+}
+
+static inline float sRGBToLinear(int value) {
+	float v = (float)value / 255;
+	if(v <= 0.04045) return v / 12.92;
+	else return powf((v + 0.055) / 1.055, 2.4);
+}
+
+static inline float signPow(float value, float exp) {
+	return copysignf(powf(fabsf(value), exp), value);
+}
+
+#endif

--- a/src/decode.c
+++ b/src/decode.c
@@ -1,0 +1,220 @@
+#include <math.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+
+
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
+static char chars[83] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz#$%*+,-.:;=?@[]^_{|}~";
+
+/*
+	Image processing functions start
+*/
+
+static float sRGBToLinear(int value) {
+	float v = (float)value / 255;
+	if(v <= 0.04045) return v / 12.92;
+	else return powf((v + 0.055) / 1.055, 2.4);
+}
+
+static float signPow(float value, float exp) {
+	return copysignf(powf(fabsf(value), exp), value);
+}
+
+static int linearTosRGB(float value) {
+	float v = fmaxf(0, fminf(1, value));
+	if(v <= 0.0031308) return v * 12.92 * 255 + 0.5;
+	else return (1.055 * powf(v, 1 / 2.4) - 0.055) * 255 + 0.5;
+}
+
+/*
+	Image processing functions end
+*/
+
+/*
+	decoder helper functions start
+*/ 
+
+static inline uint8_t clampToUByte(int * src) {
+	if( *src >= 0 && *src <= 255 )
+		return *src;
+	return (*src < 0) ? 0 : 255; 
+}
+
+
+static inline uint8_t *  createByteArray(int size) {
+	return (uint8_t *)malloc(size * sizeof(uint8_t));
+}
+
+/*
+	decoder helper functions end
+*/
+
+
+/*
+	Base-83 decoder start
+*/
+
+int decodeToInt(const char * string, int start, int end) {
+	int value = 0, iter1 = 0, iter2 = 0;
+	for( iter1 = start; iter1 < end; iter1 ++) {
+
+		int index = -1;
+		for(iter2 = 0; iter2 < 83; iter2 ++) {
+			if (chars[iter2] == string[iter1]) {
+				index = iter2;
+				break;
+			}
+		}
+
+		if (index == -1) return -1;
+		value = value * 83 + index;
+	}
+
+	return value;
+}
+
+/*
+	Base-83 decoder end
+*/
+
+/*
+	Blurhash functions start
+*/
+
+bool isValidBlurhash(const char * blurhash) {
+
+	const int hashLength = strlen(blurhash);
+
+	if ( !blurhash || strlen(blurhash) < 6) return false;
+
+	int sizeFlag = decodeToInt(blurhash, 0, 1);	//Get size from first character
+	int numY = (int)floorf(sizeFlag / 9) + 1;
+	int numX = (sizeFlag % 9) + 1;
+
+	if (hashLength != 4 + 2 * numX * numY) return false;
+
+	return true;
+}
+
+void decodeDC(int value, float * r, float * g, float * b) {
+	*r = sRGBToLinear(value >> 16); 	// R-component
+
+	*g = sRGBToLinear((value >> 8) & 255); // G-Component
+
+	*b = sRGBToLinear(value & 255);	// B-Component
+
+}
+
+
+void decodeAC(int value, float maximumValue, float * r, float * g, float * b) {
+
+    int quantR = (int)floorf(value / (19 * 19));
+	int quantG = (int)floorf(value / 19) % 19;
+	int quantB = (int)value % 19;
+
+
+	*r = signPow(((float)quantR - 9) / 9, 2.0) * maximumValue;
+
+	*g = signPow(((float)quantG - 9) / 9, 2.0) * maximumValue;
+
+	*b = signPow(((float)quantB - 9) / 9, 2.0) * maximumValue;
+}
+
+
+int decodeToArray(const char * blurhash, int width, int height, int punch, int nChannels, uint8_t * pixelArray) {
+
+	if (! isValidBlurhash(blurhash)) return -1;
+
+	if (punch < 1) punch = 1;
+
+	int sizeFlag = decodeToInt(blurhash, 0, 1);
+	int numY = (int)floorf(sizeFlag / 9) + 1;
+	int numX = (sizeFlag % 9) + 1;
+	int iter = 0;
+
+	float r = 0, g = 0, b = 0;
+
+	int quantizedMaxValue = decodeToInt(blurhash, 1, 2);
+	if (quantizedMaxValue == -1) return -1;
+
+	float maxValue = ((float)(quantizedMaxValue + 1)) / 166;
+
+
+	int colors_size = numX * numY;
+	float colors[colors_size][3];
+
+	for(iter = 0; iter < colors_size; iter ++) {
+		if (iter == 0) {
+			int value = decodeToInt(blurhash, 2, 6);
+			if (value == -1) return -1;
+			decodeDC(value, &r, &g, &b);
+			colors[iter][0] = r;
+			colors[iter][1] = g;
+			colors[iter][2] = b;
+
+		} else {
+			int value = decodeToInt(blurhash, 4 + iter * 2, 6 + iter * 2);
+			if (value == -1) return -1;
+			decodeAC(value, maxValue * punch, &r, &g, &b);
+			colors[iter][0] = r;
+			colors[iter][1] = g;
+			colors[iter][2] = b;
+		}
+	}
+
+	int bytesPerRow = width * nChannels;
+	int x = 0, y = 0, i = 0, j = 0;
+	int intR = 0, intG = 0, intB = 0;
+
+	for(y = 0; y < height; y ++) {
+		for(x = 0; x < width; x ++) {
+
+			float r = 0, g = 0, b = 0;
+
+			for(j = 0; j < numY; j ++) {
+				for(i = 0; i < numX; i ++) {
+					float basics = cos((M_PI * x * i) / width) * cos((M_PI * y * j) / height);
+					int idx = i + j * numX;
+					r += colors[idx][0] * basics;
+					g += colors[idx][1] * basics;
+					b += colors[idx][2] * basics;
+				}
+			}
+
+			intR = linearTosRGB(r);
+			intG = linearTosRGB(g);
+			intB = linearTosRGB(b);
+
+			pixelArray[nChannels * x + 0 + y * bytesPerRow] = clampToUByte(&intR);
+			pixelArray[nChannels * x + 1 + y * bytesPerRow] = clampToUByte(&intG);
+			pixelArray[nChannels * x + 2 + y * bytesPerRow] = clampToUByte(&intB);
+
+			if (nChannels == 4) 
+				pixelArray[nChannels * x + 3 + y * bytesPerRow] = 255;   // If nChannels=4, treat each pixel as RGBA instead of RGB
+			
+		}
+	}
+
+	return 0;
+}
+
+uint8_t * decode(const char * blurhash, int width, int height, int punch, int nChannels) {
+	int bytesPerRow = width * nChannels;
+	uint8_t * pixelArray = createByteArray(bytesPerRow * height);
+
+	if (decodeToArray(blurhash, width, height, punch, nChannels, pixelArray) == -1) 
+		return NULL;
+
+	return pixelArray;
+}
+
+void freePixelArray(uint8_t * array_ptr) {
+    if (array_ptr) {
+        free(array_ptr);
+    }
+}

--- a/src/decode.c
+++ b/src/decode.c
@@ -4,65 +4,23 @@
 #include <stdlib.h>
 #include <stdint.h>
 
-
-#ifndef M_PI
-#define M_PI 3.14159265358979323846
-#endif
+#include "common.h"
 
 static char chars[83] = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz#$%*+,-.:;=?@[]^_{|}~";
-
-/*
-	Image processing functions start
-*/
-
-static float sRGBToLinear(int value) {
-	float v = (float)value / 255;
-	if(v <= 0.04045) return v / 12.92;
-	else return powf((v + 0.055) / 1.055, 2.4);
-}
-
-static float signPow(float value, float exp) {
-	return copysignf(powf(fabsf(value), exp), value);
-}
-
-static int linearTosRGB(float value) {
-	float v = fmaxf(0, fminf(1, value));
-	if(v <= 0.0031308) return v * 12.92 * 255 + 0.5;
-	else return (1.055 * powf(v, 1 / 2.4) - 0.055) * 255 + 0.5;
-}
-
-/*
-	Image processing functions end
-*/
-
-/*
-	decoder helper functions start
-*/ 
 
 static inline uint8_t clampToUByte(int * src) {
 	if( *src >= 0 && *src <= 255 )
 		return *src;
-	return (*src < 0) ? 0 : 255; 
+	return (*src < 0) ? 0 : 255;
 }
-
 
 static inline uint8_t *  createByteArray(int size) {
 	return (uint8_t *)malloc(size * sizeof(uint8_t));
 }
 
-/*
-	decoder helper functions end
-*/
-
-
-/*
-	Base-83 decoder start
-*/
-
 int decodeToInt(const char * string, int start, int end) {
 	int value = 0, iter1 = 0, iter2 = 0;
 	for( iter1 = start; iter1 < end; iter1 ++) {
-
 		int index = -1;
 		for(iter2 = 0; iter2 < 83; iter2 ++) {
 			if (chars[iter2] == string[iter1]) {
@@ -70,24 +28,13 @@ int decodeToInt(const char * string, int start, int end) {
 				break;
 			}
 		}
-
 		if (index == -1) return -1;
 		value = value * 83 + index;
 	}
-
 	return value;
 }
 
-/*
-	Base-83 decoder end
-*/
-
-/*
-	Blurhash functions start
-*/
-
 bool isValidBlurhash(const char * blurhash) {
-
 	const int hashLength = strlen(blurhash);
 
 	if ( !blurhash || strlen(blurhash) < 6) return false;
@@ -97,39 +44,27 @@ bool isValidBlurhash(const char * blurhash) {
 	int numX = (sizeFlag % 9) + 1;
 
 	if (hashLength != 4 + 2 * numX * numY) return false;
-
 	return true;
 }
 
 void decodeDC(int value, float * r, float * g, float * b) {
 	*r = sRGBToLinear(value >> 16); 	// R-component
-
 	*g = sRGBToLinear((value >> 8) & 255); // G-Component
-
 	*b = sRGBToLinear(value & 255);	// B-Component
-
 }
 
-
 void decodeAC(int value, float maximumValue, float * r, float * g, float * b) {
-
-    int quantR = (int)floorf(value / (19 * 19));
+	int quantR = (int)floorf(value / (19 * 19));
 	int quantG = (int)floorf(value / 19) % 19;
 	int quantB = (int)value % 19;
 
-
 	*r = signPow(((float)quantR - 9) / 9, 2.0) * maximumValue;
-
 	*g = signPow(((float)quantG - 9) / 9, 2.0) * maximumValue;
-
 	*b = signPow(((float)quantB - 9) / 9, 2.0) * maximumValue;
 }
 
-
 int decodeToArray(const char * blurhash, int width, int height, int punch, int nChannels, uint8_t * pixelArray) {
-
 	if (! isValidBlurhash(blurhash)) return -1;
-
 	if (punch < 1) punch = 1;
 
 	int sizeFlag = decodeToInt(blurhash, 0, 1);
@@ -138,12 +73,10 @@ int decodeToArray(const char * blurhash, int width, int height, int punch, int n
 	int iter = 0;
 
 	float r = 0, g = 0, b = 0;
-
 	int quantizedMaxValue = decodeToInt(blurhash, 1, 2);
 	if (quantizedMaxValue == -1) return -1;
 
 	float maxValue = ((float)(quantizedMaxValue + 1)) / 166;
-
 
 	int colors_size = numX * numY;
 	float colors[colors_size][3];
@@ -194,9 +127,9 @@ int decodeToArray(const char * blurhash, int width, int height, int punch, int n
 			pixelArray[nChannels * x + 1 + y * bytesPerRow] = clampToUByte(&intG);
 			pixelArray[nChannels * x + 2 + y * bytesPerRow] = clampToUByte(&intB);
 
-			if (nChannels == 4) 
+			if (nChannels == 4)
 				pixelArray[nChannels * x + 3 + y * bytesPerRow] = 255;   // If nChannels=4, treat each pixel as RGBA instead of RGB
-			
+
 		}
 	}
 
@@ -207,14 +140,13 @@ uint8_t * decode(const char * blurhash, int width, int height, int punch, int nC
 	int bytesPerRow = width * nChannels;
 	uint8_t * pixelArray = createByteArray(bytesPerRow * height);
 
-	if (decodeToArray(blurhash, width, height, punch, nChannels, pixelArray) == -1) 
+	if (decodeToArray(blurhash, width, height, punch, nChannels, pixelArray) == -1)
 		return NULL;
-
 	return pixelArray;
 }
 
-void freePixelArray(uint8_t * array_ptr) {
-    if (array_ptr) {
-        free(array_ptr);
-    }
+void freePixelArray(uint8_t * pixelArray) {
+	if (pixelArray) {
+		free(pixelArray);
+	}
 }

--- a/src/encode.c
+++ b/src/encode.c
@@ -3,6 +3,8 @@
 #include <string.h>
 #include <math.h>
 
+#include "common.h"
+
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
 #endif
@@ -10,11 +12,8 @@
 static float *multiplyBasisFunction(int xComponent, int yComponent, int width, int height, uint8_t *rgb, size_t bytesPerRow);
 static char *encode_int(int value, int length, char *destination);
 
-static int linearTosRGB(float value);
-static float sRGBToLinear(int value);
 static int encodeDC(float r, float g, float b);
 static int encodeAC(float r, float g, float b, float maximumValue);
-static float signPow(float value, float exp);
 
 const char *blurHashForPixels(int xComponents, int yComponents, int width, int height, uint8_t *rgb, size_t bytesPerRow) {
 	static char buffer[2 + 4 + (9 * 9 - 1) * 2 + 1];
@@ -95,18 +94,6 @@ static float *multiplyBasisFunction(int xComponent, int yComponent, int width, i
 	return result;
 }
 
-static int linearTosRGB(float value) {
-	float v = fmaxf(0, fminf(1, value));
-	if(v <= 0.0031308) return v * 12.92 * 255 + 0.5;
-	else return (1.055 * powf(v, 1 / 2.4) - 0.055) * 255 + 0.5;
-}
-
-static float sRGBToLinear(int value) {
-	float v = (float)value / 255;
-	if(v <= 0.04045) return v / 12.92;
-	else return powf((v + 0.055) / 1.055, 2.4);
-}
-
 static int encodeDC(float r, float g, float b) {
 	int roundedR = linearTosRGB(r);
 	int roundedG = linearTosRGB(g);
@@ -120,10 +107,6 @@ static int encodeAC(float r, float g, float b, float maximumValue) {
 	int quantB = fmaxf(0, fminf(18, floorf(signPow(b / maximumValue, 0.5) * 9 + 9.5)));
 
 	return quantR * 19 * 19 + quantG * 19 + quantB;
-}
-
-static float signPow(float value, float exp) {
-	return copysignf(powf(fabsf(value), exp), value);
 }
 
 static char characters[83]="0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz#$%*+,-.:;=?@[]^_{|}~";

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -5,30 +5,39 @@ import pytest
 from PIL import Image
 from blurhash import decode, PixelMode
 
+
 def test_decode_blurhash():
     image = decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", 416, 416)
     assert type(image) == Image.Image
 
 
 def test_decode_rgba():
-    image = decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", 416, 416, mode = PixelMode.RGBA )
+    image = decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", 416, 416,
+                   mode=PixelMode.RGBA)
+
     assert image.getbands() == ('R', 'G', 'B', 'A')
 
+
 def test_decode_rgb():
-    image = decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", 416, 416, mode = PixelMode.RGB)
+    image = decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", 416, 416,
+                   mode=PixelMode.RGB)
     assert image.getbands() == ('R', 'G', 'B')
 
+
 def test_decode_punch():
-    image = decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", 416, 416, punch = 2)
+    image = decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", 416, 416, punch=2)
     assert type(image) == Image.Image
+
 
 def test_decode_invalid_blurhash():
     with pytest.raises(ValueError):
         decode("#MwS|WCWEM{R", 416, 416)
 
+
 def test_decode_invalid_mode():
     with pytest.raises(ValueError):
-        decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", 416, 416, mode = 'XXX')
+        decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", 416, 416, mode='XXX')
+
 
 def test_decode_invalid_width():
     with pytest.raises(ValueError):
@@ -39,6 +48,12 @@ def test_decode_invalid_height():
     with pytest.raises(ValueError):
         decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", 416, 0)
 
+
 def test_decode_invalid_punch():
     with pytest.raises(ValueError):
-        decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", 416, 416, punch = -2)
+        decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", 416, 416, punch=-2)
+
+
+def test_decode_valid_width_height():
+    image = decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", 640, 480)
+    assert (image.width == 640 and image.height == 480)

--- a/tests/test_decode.py
+++ b/tests/test_decode.py
@@ -1,0 +1,44 @@
+from __future__ import absolute_import
+
+import pytest
+
+from PIL import Image
+from blurhash import decode, PixelMode
+
+def test_decode_blurhash():
+    image = decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", 416, 416)
+    assert type(image) == Image.Image
+
+
+def test_decode_rgba():
+    image = decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", 416, 416, mode = PixelMode.RGBA )
+    assert image.getbands() == ('R', 'G', 'B', 'A')
+
+def test_decode_rgb():
+    image = decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", 416, 416, mode = PixelMode.RGB)
+    assert image.getbands() == ('R', 'G', 'B')
+
+def test_decode_punch():
+    image = decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", 416, 416, punch = 2)
+    assert type(image) == Image.Image
+
+def test_decode_invalid_blurhash():
+    with pytest.raises(ValueError):
+        decode("#MwS|WCWEM{R", 416, 416)
+
+def test_decode_invalid_mode():
+    with pytest.raises(ValueError):
+        decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", 416, 416, mode = 'XXX')
+
+def test_decode_invalid_width():
+    with pytest.raises(ValueError):
+        decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", -416, 416)
+
+
+def test_decode_invalid_height():
+    with pytest.raises(ValueError):
+        decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", 416, 0)
+
+def test_decode_invalid_punch():
+    with pytest.raises(ValueError):
+        decode("LlMF%n00%#MwS|WCWEM{R*bbWBbH", 416, 416, punch = -2)


### PR DESCRIPTION
@lautat 
This PR adds `decode.c` and Python wrapper for the same. 
The following functions are added newly :
`decode` : Which takes blurhash, width, height, punch and mode as input and returns `PIL.Image` object which can be used to manipulate the image further by the caller. Here `mode` parameter is either `RGB` or `RGBA`. (3 or 4 channels)

`is_valid_blurhash` : Validates the blurhash, this function can be used by those who just want to know if they are dealing with the correct blurhash string, without decoding.

Let me know if you need any changes.

Thanks and Regards,
Prasanna