### PR TITLE
add an optional max_size argument to encode() for speed & convenience

### DIFF
--- a/src/blurhash/__init__.py
+++ b/src/blurhash/__init__.py
@@ -29,8 +29,10 @@ class BlurhashDecodeError(Exception):
         return "Failed to decode blurhash {}".format(self.blurhash)
 
 
-def encode(image_file, x_components, y_components):
+def encode(image_file, x_components, y_components, max_size=()):
     image = Image.open(image_file).convert('RGB')
+    if max_size:
+        image.thumbnail(max_size)
     red_band = image.getdata(band=0)
     green_band = image.getdata(band=1)
     blue_band = image.getdata(band=2)


### PR DESCRIPTION
Providing max_size to encode() will first resize the image to max_size (by creating an Image thumbnail), and will then create the blurhash. Resizing first will achieve much faster hashing for large images.