### PR TITLE
Image needs to be loaded as binary stream

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Create blurhash from image file
 ```python
 import blurhash
 
-with open('image.jpg', 'r') as image_file:
+with open('image.jpg', 'rb') as image_file:
     hash = blurhash.encode(image_file, x_components=4, y_components=3)
 ```
 You can also pass file name as parameter to the function


### PR DESCRIPTION
UnicodeDecodeError appears when image is opened as text. Tested on Python 3.7.10