### PR TITLE
permit existing PIL images to be encoded directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@ import blurhash
 with open('image.jpg', 'rb') as image_file:
     hash = blurhash.encode(image_file, x_components=4, y_components=3)
 ```
+Alternatively, scale the image to produce a faster hash, and create a blurhash from the in-memory image directly
+```python
+import blurhash
+from PIL import Image
+
+with Image.open('image.jpg') as image:
+  image.thumbnail(( 100, 100 ))
+  hash = blurhash.encode(image, x_components=4, y_components=3)
+```
 You can also pass file name as parameter to the function
 ```python
 import blurhash

--- a/src/blurhash/__init__.py
+++ b/src/blurhash/__init__.py
@@ -29,8 +29,11 @@ class BlurhashDecodeError(Exception):
         return "Failed to decode blurhash {}".format(self.blurhash)
 
 
-def encode(image_file, x_components, y_components):
-    image = Image.open(image_file).convert('RGB')
+def encode(image, x_components, y_components):
+    if not isinstance(image, Image.Image):
+        image = Image.open(image)
+    if image.mode != 'RGB':
+        image = image.convert('RGB')
     red_band = image.getdata(band=0)
     green_band = image.getdata(band=1)
     blue_band = image.getdata(band=2)

--- a/tests/test_encode.py
+++ b/tests/test_encode.py
@@ -2,12 +2,20 @@ from __future__ import absolute_import
 
 import pytest
 
+from PIL import Image
 from blurhash import encode
 
 
 def test_encode_file():
     with open('tests/pic2.png', 'rb') as image_file:
         result = encode(image_file, 4, 3)
+
+    assert result == 'LlMF%n00%#MwS|WCWEM{R*bbWBbH'
+
+
+def test_encode_pil_image():
+    with Image.open('tests/pic2.png') as image:
+        result = encode(image, 4, 3)
 
     assert result == 'LlMF%n00%#MwS|WCWEM{R*bbWBbH'
 


### PR DESCRIPTION
I'd like to be able to run blurhash on images in memory (i.e: not from a file on disk)

This patch should be a non-breaking change, that also allows PIL images to be passed in and encoded directly, with colorspace conversion if necessary.

An example flow would be:
- Open image
- Resize to make blurhash quicker
- Run blurhash