### PR TITLE
Make blurhash encode thread-safe

### DIFF
--- a/src/blurhash/__init__.py
+++ b/src/blurhash/__init__.py
@@ -47,9 +47,17 @@ def encode(image, x_components, y_components):
     height = _ffi.cast('int', height)
     x_components = _ffi.cast('int', x_components)
     y_components = _ffi.cast('int', y_components)
+    destination = _ffi.new("char[]", 2 + 4 + (9 * 9 - 1) * 2 + 1)
 
-    result = _lib.create_hash_from_pixels(x_components, y_components, width,
-                                          height, rgb, bytes_per_row)
+    result = _lib.create_hash_from_pixels(
+        x_components,
+        y_components,
+        width,
+        height,
+        rgb,
+        bytes_per_row,
+        destination,
+    )
 
     if result == _ffi.NULL:
         raise ValueError('Invalid x_components or y_components')

--- a/src/build_blurhash.py
+++ b/src/build_blurhash.py
@@ -12,7 +12,8 @@ ffibuilder.set_source('blurhash._functions', '''
 
     const char* blurHashForPixels(int x_components, int y_components,
                                   int width, int height,
-                                  uint8_t * rgb, size_t bytesPerRow);
+                                  uint8_t * rgb, size_t bytesPerRow,
+                                  char* destination);
 
     int decodeToArray(const char* blurhash, int width, int height,
                       int punch, int n_channels,
@@ -23,9 +24,10 @@ ffibuilder.set_source('blurhash._functions', '''
 
     const char* create_hash_from_pixels(int x_components, int y_components,
                                         int width, int height, uint8_t* rgb,
-                                        size_t bytes_per_row) {
+                                        size_t bytes_per_row,
+                                        char* destination) {
         return blurHashForPixels(x_components, y_components, width, height,
-                                 rgb, bytes_per_row);
+                                 rgb, bytes_per_row, destination);
     }
 
     int create_pixels_from_blurhash(const char * blurhash, int width,
@@ -46,7 +48,8 @@ ffibuilder.set_source('blurhash._functions', '''
 ffibuilder.cdef('''
     const char* create_hash_from_pixels(int x_components, int y_components,
                                         int width, int height, uint8_t* rgb,
-                                        size_t bytes_per_row);
+                                        size_t bytes_per_row,
+                                        char* destination);
     int create_pixels_from_blurhash(const char * blurhash, int width,
                                     int height, int punch, int nChannels,
                                     uint8_t * pixel_array);

--- a/src/encode.c
+++ b/src/encode.c
@@ -21,9 +21,7 @@ static char *encode_int(int value, int length, char *destination);
 static int encodeDC(float r, float g, float b);
 static int encodeAC(float r, float g, float b, float maximumValue);
 
-const char *blurHashForPixels(int xComponents, int yComponents, int width, int height, uint8_t *rgb, size_t bytesPerRow) {
-	static char buffer[2 + 4 + (9 * 9 - 1) * 2 + 1];
-
+const char *blurHashForPixels(int xComponents, int yComponents, int width, int height, uint8_t *rgb, size_t bytesPerRow, char *destination) {
 	if(xComponents < 1 || xComponents > 9) return NULL;
 	if(yComponents < 1 || yComponents > 9) return NULL;
 
@@ -46,7 +44,7 @@ const char *blurHashForPixels(int xComponents, int yComponents, int width, int h
 	float *dc = factors[0];
 	float *ac = dc + 3;
 	int acCount = xComponents * yComponents - 1;
-	char *ptr = buffer;
+	char *ptr = destination;
 
 	int sizeFlag = (xComponents - 1) + (yComponents - 1) * 9;
 	ptr = encode_int(sizeFlag, 1, ptr);
@@ -74,7 +72,7 @@ const char *blurHashForPixels(int xComponents, int yComponents, int width, int h
 
 	*ptr = 0;
 
-	return buffer;
+	return destination;
 }
 
 static struct RGB multiplyBasisFunction(int xComponent, int yComponent, int width, int height, uint8_t *rgb, size_t bytesPerRow) {


### PR DESCRIPTION
This removes usage of static buffers in the blurhash encoder code. C extensions can run concurrently in Python, so using a static buffer could cause issues when the function is invoked from multiple threads.

Fixes #18